### PR TITLE
$2 in up and down. Add Current command useful for script

### DIFF
--- a/common/pulseaudio-ctl.in
+++ b/common/pulseaudio-ctl.in
@@ -103,37 +103,42 @@ setup() {
 
 checkconfig
 setup
+# checks if exist a valid $2 
+PERC=5
+[[ -n "$2" ]] && [[ $(is_integer "${2%%%}") == '1' ]] && PERC=${2%%%} 
 case "$1" in
   U|u|[U,u]p)
-    # raise volume by 5% or set it to the upper threshold
+    # raise volume by $PERC% or set it to the upper threshold
     # in cases where external apps have pushed it above
+    [[ "$(( $PERC + $CURVOL ))" -gt "$UPPER_THRESHOLD" ]] && PERC="$(( $UPPER_THRESHOLD - $CURVOL ))"
     [[ "$CURVOL" -ge $UPPER_THRESHOLD ]] && pactl set-sink-volume "$SINK" $UPPER_THRESHOLD% ||
-      pactl set-sink-volume "$SINK" -- +5%
-    CURVOL=$(pacmd list-sinks|grep -A 15 '* index'| awk '/volume: front/{ print $5 }' | sed 's/%//g')
+       pactl set-sink-volume "$SINK" -- +$PERC%
+   CURVOL=$(pacmd list-sinks|grep -A 15 '* index'| awk '/volume: front/{ print $5 }' | sed 's/%//g')
     [[ -n "$NOTIFY" ]] &&
-      notify-send -t 1000 -i multimedia-volume-control --hint=int:transient:1 --hint=int:value:$CURVOL --hint=string:synchronous:volume "volume up" ""
+      notify-send -t 1000 -i multimedia-volume-control --hint=int:transient:1 --hint=int:value:$CURVOL --hint=string:synchronous:volume "Volume up $PERC%" ""
     ;;
   D|d|[D,d]own|[D,d]o)
-    # lowers volume by 5%
+    # lowers volume by $PERC%
+    [[ "$PERC" -gt "$CURVOL" ]] && PERC="$CURVOL"
     [[ "$CURVOL" -le 0 ]] && exit 0 ||
-      pactl set-sink-volume "$SINK" -- -5%
+      pactl set-sink-volume "$SINK" -- -$PERC%
     CURVOL=$(pacmd list-sinks|grep -A 15 '* index'| awk '/volume: front/{ print $5 }' | sed 's/%//g')
     [[ -n "$NOTIFY" ]] &&
-      notify-send -t 1000 -i multimedia-volume-control --hint=int:transient:1 --hint=int:value:$CURVOL --hint=string:synchronous:volume "volume down" ""
+      notify-send -t 1000 -i multimedia-volume-control --hint=int:transient:1 --hint=int:value:$CURVOL --hint=string:synchronous:volume "Volume down $PERC%" ""
     ;;
   M|m|[M,m]u|[M,m]ute)
     # mutes the volume entirely
     pactl set-sink-mute "$SINK" toggle
     MUTED=$(pacmd list-sinks|grep -A 15 '* index'|awk '/muted:/{ print $2 }')
     [[ -n "$NOTIFY" ]] &&
-      notify-send -t 1000 --hint=int:transient:1 "mute toggle" "muted: $MUTED" --icon=audio-volume-muted
+      notify-send -t 1000 --hint=int:transient:1 "Mute toggle" "Muted: $MUTED" --icon=audio-volume-muted
     ;;
   [M,m]i|[M,m]ute-[I,i]nput)
     # mutes the microphone entirely
     pactl set-source-mute "$SOURCE" toggle
     SOURCE_MUTED=$(pacmd list-sources|grep -A 15 '* index'|awk '/muted:/{ print $2 }')
     [[ -n "$NOTIFY" ]] &&
-      notify-send -t 1000 --hint=int:transient:1 "mute toggle" "muted: $SOURCE_MUTED" --icon=audio-volume-muted
+      notify-send -t 1000 --hint=int:transient:1 "Mute toggle" "Muted: $SOURCE_MUTED" --icon=audio-volume-muted
     ;;
   set)
     NEWVOL="${2%%%}"
@@ -142,7 +147,7 @@ case "$1" in
       pactl set-sink-volume "$SINK" -- $NEWVOL%
     CURVOL=$(pacmd list-sinks|grep -A 15 '* index'| awk '/volume: front/{ print $5 }' | sed 's/%//g')
     [[ -n "$NOTIFY" ]] &&
-      notify-send -t 1000 --hint=int:transient:1 "volume set" "level: $CURVOL" --icon=multimedia-volume-control
+      notify-send -t 1000 --hint=int:transient:1 "Volume set" "Level: $CURVOL" --icon=multimedia-volume-control
     ;;
   atmost)
     NEWVOL="${2%%%}"
@@ -152,7 +157,11 @@ case "$1" in
       pactl set-sink-volume "$SINK" -- $NEWVOL%
     CURVOL=$(pacmd list-sinks|grep -A 15 '* index'| awk '/volume: front/{ print $5 }' | sed 's/%//g')
     [[ -n "$NOTIFY" ]] &&
-      notify-send -t 1000 --hint=int:transient:1 "atmost set" "level: $CURVOL" --icon=multimedia-volume-control
+      notify-send -t 1000 --hint=int:transient:1 "Atmost set" "Level: $CURVOL" --icon=multimedia-volume-control
+    ;;
+  C|c|[C,c]urrent)
+    # useful only for scripting
+    echo $CURVOL%
     ;;
   *)
     echo -e "${BLD}pulseaudio-ctl v$VERS${NRM}"


### PR DESCRIPTION
Hi.
I use your script every day on my laptop.
I've added some features that I think could be interesting. In particular:

pulseaudio-ctl up N  or pulseaudio-ctl up N% for increase volume of N%
Same with "down".
pulseaudio-ctl u or d  (without N) are like before (5%).

"pulseaudio-ctl C|c|[C,c]urrent" simply print the current volume (useful for scripting).

:D
