### PR TITLE
Bugfixes, new full-status feature

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,6 @@ uninstall:
 	$(RM) -rf "$(DESTDIR)$(SKELDIR)"
 	$(RM) "$(DESTDIR)$(ZSHDIR)/_pulseaudio-ctl"
 
-install: install-bin install-man
+install: all install-bin install-man
 
 .PHONY: clean install-bin install-man uninstall

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ Q = @
 all:
 	$(Q)echo -e '\033[1;32mSetting version\033[0m'
 	$(Q)sed -e 's/@VERSION@/'$(VERSION)'/' common/$(PN).in >common/$(PN)
+	$(Q)sed -i common/$(PN) -e 's|@SKELDIR@|'$(SKELDIR)'|'
 
 clean:
 	$(RM) -f common/$(PN)
@@ -21,7 +22,7 @@ install-bin:
 	install -Dm755 common/$(PN) "$(DESTDIR)$(BINDIR)/$(PN)"
 	install -Dm644 common/config.skel "$(DESTDIR)$(SKELDIR)/config.skel"
 	install -p -dm755 "$(DESTDIR)$(ZSHDIR)"
-	install -Dm644 common/zsh-completion "$(DESTDIR)/$(ZSHDIR)/_pulseaudio-ctl"
+	install -Dm644 common/zsh-completion "$(DESTDIR)$(ZSHDIR)/_pulseaudio-ctl"
 
 install-man:
 	$(Q)echo -e '\033[1;32mInstalling manpage...\033[0m'
@@ -32,7 +33,7 @@ uninstall:
 	$(RM) "$(DESTDIR)$(BINDIR)/$(PN)"
 	$(RM) "$(DESTDIR)$(MANDIR)/$(PN).1.gz"
 	$(RM) -rf "$(DESTDIR)$(SKELDIR)"
-	$(RM) "$(DESTDIR)/$(ZSHDIR)/_pulseaudio-ctl"
+	$(RM) "$(DESTDIR)$(ZSHDIR)/_pulseaudio-ctl"
 
 install: install-bin install-man
 

--- a/Makefile
+++ b/Makefile
@@ -9,13 +9,20 @@ ZSHDIR = $(PREFIX)/share/zsh/site-functions
 RM = rm
 Q = @
 
-all:
+all: common/$(PN) doc/$(PN).1.gz
+
+common/$(PN): common/$(PN).in
 	$(Q)echo -e '\033[1;32mSetting version\033[0m'
 	$(Q)sed -e 's/@VERSION@/'$(VERSION)'/' common/$(PN).in >common/$(PN)
 	$(Q)sed -i common/$(PN) -e 's|@SKELDIR@|'$(SKELDIR)'|'
 
+doc/$(PN).1.gz: doc/$(PN).1
+	$(Q)echo -e '\033[1;32mCompressing manpage\033[0m'
+	gzip -9 -c doc/$(PN).1 > doc/$(PN).1.gz
+
 clean:
 	$(RM) -f common/$(PN)
+	$(RM) -f doc/$(PN).1.gz
 
 install-bin:
 	$(Q)echo -e '\033[1;32mInstalling main script, initd and config...\033[0m'
@@ -26,8 +33,7 @@ install-bin:
 
 install-man:
 	$(Q)echo -e '\033[1;32mInstalling manpage...\033[0m'
-	install -Dm644 doc/$(PN).1 "$(DESTDIR)$(MANDIR)/$(PN).1"
-	gzip -9 "$(DESTDIR)$(MANDIR)/$(PN).1"
+	install -Dm644 doc/$(PN).1.gz "$(DESTDIR)$(MANDIR)/$(PN).1.gz"
 
 uninstall:
 	$(RM) "$(DESTDIR)$(BINDIR)/$(PN)"
@@ -37,4 +43,4 @@ uninstall:
 
 install: all install-bin install-man
 
-.PHONY: clean install-bin install-man uninstall
+.PHONY: all clean install-bin install-man uninstall

--- a/common/pulseaudio-ctl.in
+++ b/common/pulseaudio-ctl.in
@@ -9,7 +9,7 @@
 # https://github.com/graysky2/pulseaudio-ctl
 
 VERS="@VERSION@"
-SKEL="/usr/share/pulseaudio-ctl/config.skel"
+SKEL="@SKELDIR@/config.skel"
 CONFIG="${XDG_CONFIG_HOME:-$HOME/.config}/pulseaudio-ctl/config"
 
 BLD="\e[01m"

--- a/common/pulseaudio-ctl.in
+++ b/common/pulseaudio-ctl.in
@@ -223,6 +223,11 @@ case "$1" in
     # useful only for scripting
     echo $CURVOL%
     ;;
+  [F,f]s|[F,f]ull-[S,s]tatus)
+    # useful for scripting.
+    # returns current volume and sink and source mute state
+    echo $CURVOL $MUTED $SOURCE_MUTED
+    ;;
   *)
     # send to notify-send if enabled
     [[ $USEN -eq 1 ]] &&

--- a/doc/pulseaudio-ctl.1
+++ b/doc/pulseaudio-ctl.1
@@ -48,6 +48,10 @@ Like the 'set' option only takes effect if the current volume is higher than the
 .B
 current
 Print the current volume level to STDOUT
+.TP
+.B
+full-status
+Print the current volume level, the sink mute state and the source mute state to stdout
 .SH EXAMPLES
 Increase vol level by 5 %
 .PP


### PR DESCRIPTION
Fixed a bug in the pulseaudio-ctl program (1st commit), restructured the makefile (2nd and 3rd commit) and added a full-status command to pulseaudio-ctl (4th commit). This command writes out the current volume and the mute state of the sink and source. Very useful for scripting.