### PR TITLE
Allow setting volume to upper threshold

### DIFF
--- a/common/pulseaudio-ctl.in
+++ b/common/pulseaudio-ctl.in
@@ -196,7 +196,7 @@ case "$1" in
     ;;
   set)
     NEWVOL="${2%%%}"
-    [[ "$NEWVOL" -ge $UPPER_THRESHOLD ]] && exit 0 ||
+    [[ "$NEWVOL" -gt $UPPER_THRESHOLD ]] && exit 0 ||
       [[ "$NEWVOL" -le 0 ]] && exit 0 ||
       case "$PCV" in
         0|1) pactl set-sink-volume "$SINK" -- $NEWVOL% ;;


### PR DESCRIPTION
I found that I was unable to run `pulseaudio-ctl set 100` with my `UPPER_THRESHOLD=100`. This change fixes that.

If that was desired behavior, I'll respect that. Otherwise, let me know if this pull request is lacking in any way.