### PR TITLE
Allow set and atmost commands to accept 0 and the upper threshold

### DIFF
--- a/common/pulseaudio-ctl.in
+++ b/common/pulseaudio-ctl.in
@@ -255,7 +255,7 @@ case "$1" in
   set)
     NEWVOL="${2%%%}"
     [[ "$NEWVOL" -gt $UPPER_THRESHOLD ]] && exit 0 ||
-      [[ "$NEWVOL" -le 0 ]] && exit 0 ||
+      [[ "$NEWVOL" -lt 0 ]] && exit 0 ||
       case "$PCV" in
         0|1) pactl set-sink-volume "$SINK" -- $NEWVOL% ;;
         2) pactl set-sink-volume "$SINK" $NEWVOL% ;;
@@ -269,8 +269,8 @@ case "$1" in
   atmost)
     NEWVOL="${2%%%}"
     [[ "$CURVOL" -le "$NEWVOL" ]] && exit 0 ||
-      [[ "$NEWVOL" -ge $UPPER_THRESHOLD ]] && exit 0 ||
-      [[ "$NEWVOL" -le 0 ]] && exit 0 ||
+      [[ "$NEWVOL" -gt $UPPER_THRESHOLD ]] && exit 0 ||
+      [[ "$NEWVOL" -lt 0 ]] && exit 0 ||
       case "$PCV" in
         0|1) pactl set-sink-volume "$SINK" -- $NEWVOL% ;;
         2) pactl set-sink-volume "$SINK" $NEWVOL% ;;


### PR DESCRIPTION
I find myself often saying `set 0` (along with the `set $UPPER_THRESHOLD` from before), so here's a change that allows it. I also applied the same treatment to the `atmost` command.