### PR TITLE
Set exitcode 0 for all cases

### DIFF
--- a/common/pulseaudio-ctl.in
+++ b/common/pulseaudio-ctl.in
@@ -320,8 +320,9 @@ case "$1" in
     echo -e " ${BLD}Detected sink    : ${NRM}${BLU}$SINK${NRM}"
     echo -e " ${BLD}Detected source  : ${NRM}${BLU}$SOURCE${NRM}"
     echo -e " ${BLD}Pulse version    : ${NRM}${BLU}$PAVERSION${NRM}"
-    exit 0
     ;;
 esac
+
+exit 0
 
 # vim:set ts=8 sts=2 sw=2 et:


### PR DESCRIPTION
Some callers of pulseaudio-ctl might check the exitcode and warn
if its not 0 indicating failure. Enlightenment does this for
key actions and most actions would return 1 as exitcode because
[[ $USEK -eq 1 ]] is not true in my setup and being the last command
it set the exitcode for the while script