### PR TITLE
Add override sink option

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,13 @@ BARCHART=yes
 
 # Use KDE OSD notification. Set to any value to enable this feature.
 KDE_OSD=yes
+
+# Allows you to choose the default sink based on a word or phrase that is unique
+# to the hardware device that you're trying to target. Use this if you have
+# multiple devices but only want to use pulseaudio-ctl to manage one of them
+# specifically. Use the command "pacmd list-sinks" to find a list of available
+# output devices/sinks.
+#OVERRIDE_SINK=wireless
 ```
 
 If config file isn't present script uses default value 100 for the UPPER_THRESHOLD and notifications are disabled by default.

--- a/common/pulseaudio-ctl.in
+++ b/common/pulseaudio-ctl.in
@@ -130,17 +130,17 @@ checkconfig() {
 refreshcurvol() {
   # this worked some versions of PA 4 but is no longer valid with v5
   # CURVOL=$(pacmd list-sinks|grep -A 15 '* index'| awk '/base volume: /{ print $5 }'|sed 's/%//')
-  [[ $PCV -eq 0 ]] && 
-  CURVOL=$(pacmd list-sinks|grep -A 15 '* index'| awk '/volume: /{ print $3 }' | grep -m 1 % |sed 's/[%|,]//g') ||
-    CURVOL=$(pacmd list-sinks|grep -A 15 '* index'| awk '/volume: front/{ print $5 }' | sed 's/[%|,]//g')
+  [[ $PCV -eq 0 ]] &&
+  CURVOL=$(pacmd list-sinks|grep -A 15 "index: ${SINK}"| awk '/volume: /{ print $3 }' | grep -m 1 % |sed 's/[%|,]//g') ||
+    CURVOL=$(pacmd list-sinks|grep -A 15 "index: ${SINK}"| awk '/volume: front/{ print $5 }' | sed 's/[%|,]//g')
 }
 
 refreshsrcvol() {
   # this worked some versions of PA 4 but is no longer valid with v5
   # SRCVOL=$(pacmd list-sources|grep -A 15 '* index'| awk '/base volume: /{ print $5 }'|sed 's/%//')
   [[ $PCV -eq 0 ]] &&
-  SRCVOL=$(pacmd list-sources|grep -A 15 '* index'| awk '/volume: /{ print $3 }' | grep -m 1 % |sed 's/[%|,]//g') ||
-    SRCVOL=$(pacmd list-sources|grep -A 15 '* index'| awk '/volume: front/{ print $5 }' | sed 's/[%|,]//g')
+  SRCVOL=$(pacmd list-sources|grep -A 15 "index: ${SOURCE}"| awk '/volume: /{ print $3 }' | grep -m 1 % |sed 's/[%|,]//g') ||
+    SRCVOL=$(pacmd list-sources|grep -A 15 "index: ${SOURCE}"| awk '/volume: front/{ print $5 }' | sed 's/[%|,]//g')
 }
 
 refreshbarvolperc() {
@@ -150,14 +150,14 @@ refreshbarvolperc() {
 }
 
 setup() {
-  if [[ -n "${OVERRIDE_SINK}" ]]; then
-    SINK=$(pacmd list-sinks|grep -iB 1 "${OVERRIDE_SINK}"|grep "index:"|sed -r 's/.*index: *([0-9]+)/\1/g')
+  if [[ -n "${DEFAULT_SINK}" ]]; then
+    SINK=$(pacmd list-sinks|grep -iB 1 "${DEFAULT_SINK}"|grep "index:"|sed -r 's/.*index: *([0-9]+)/\1/g')
   else
     SINK=$(pacmd list-sinks|awk '/\* index:/{ print $3 }')
   fi
   SOURCE=$(pacmd list-sources|awk '/\* index:/{ print $3 }')
-  MUTED=$(pacmd list-sinks|grep -A 15 '* index'|awk '/muted:/{ print $2 }')
-  SOURCE_MUTED=$(pacmd list-sources|grep -A 15 '* index'|awk '/muted:/{ print $2 }')
+  MUTED=$(pacmd list-sinks|grep -A 15 "index: ${SINK}"|awk '/muted:/{ print $2 }')
+  SOURCE_MUTED=$(pacmd list-sources|grep -A 15 "index: ${SOURCE}"|awk '/muted:/{ print $2 }')
   
   refreshcurvol # sets CURVOL ahead of integer check
 
@@ -233,7 +233,7 @@ case "$1" in
       NEW_MUTE="$2"
     fi
     pactl set-sink-mute "$SINK" "$NEW_MUTE"
-    MUTED=$(pacmd list-sinks|grep -A 15 '* index'|awk '/muted:/{ print $2 }')
+    MUTED=$(pacmd list-sinks|grep -A 15 "index: ${SINK}"|awk '/muted:/{ print $2 }')
     [[ $USEN -eq 1 ]] &&
       notify-send -t 1000 --hint=int:transient:1 "Mute toggle" "Muted: $MUTED" --icon=audio-volume-muted
     if [[ $USEK -eq 1 ]]; then
@@ -252,7 +252,7 @@ case "$1" in
       NEW_MUTE="$2"
     fi
     pactl set-source-mute "$SOURCE" "$NEW_MUTE"
-    SOURCE_MUTED=$(pacmd list-sources|grep -A 15 '* index'|awk '/muted:/{ print $2 }')
+    SOURCE_MUTED=$(pacmd list-sources|grep -A 15 "index: ${SOURCE}"|awk '/muted:/{ print $2 }')
     [[ $USEN -eq 1 ]] &&
       notify-send -t 1000 --hint=int:transient:1 "Mute toggle" "Muted: $SOURCE_MUTED" --icon=audio-volume-muted
     if [[ $USEK -eq 1 ]]; then

--- a/common/pulseaudio-ctl.in
+++ b/common/pulseaudio-ctl.in
@@ -150,7 +150,11 @@ refreshbarvolperc() {
 }
 
 setup() {
-  SINK=$(pacmd list-sinks|awk '/\* index:/{ print $3 }')
+  if [[ -n "${OVERRIDE_SINK}" ]]; then
+    SINK=$(pacmd list-sinks|grep -iB 1 "${OVERRIDE_SINK}"|grep "index:"|sed -r 's/.*index: *([0-9]+)/\1/g')
+  else
+    SINK=$(pacmd list-sinks|awk '/\* index:/{ print $3 }')
+  fi
   SOURCE=$(pacmd list-sources|awk '/\* index:/{ print $3 }')
   MUTED=$(pacmd list-sinks|grep -A 15 '* index'|awk '/muted:/{ print $2 }')
   SOURCE_MUTED=$(pacmd list-sources|grep -A 15 '* index'|awk '/muted:/{ print $2 }')


### PR DESCRIPTION
I don't know if you're interested in this change or not, but I have found it useful for myself so I figured I would see if you were interested in it upstream.

Basically, if you have multiple output sinks there are times in which I want pulseaudio-ctl to manage a sink that is not the default sink. So I created an OVERRIDE_SINK config item. I've been using it locally for several weeks and it works well.

Let me know what you think.