### PR TITLE
expose appname as pulseaudio-ctl and not notify-send

### DIFF
--- a/common/pulseaudio-ctl.in
+++ b/common/pulseaudio-ctl.in
@@ -198,8 +198,8 @@ case "$1" in
     refreshbarvolperc
     if [[ $USEN -eq 1 ]]; then
       [[ $USEB -eq 1 ]] &&
-        notify-send -t 1000 -i multimedia-volume-control --hint=int:transient:1 --hint=int:value:$UPPER_THRESHOLD_AWARE_VOL --hint=string:synchronous:volume "Volume up $PERC %" "" ||
-        notify-send -t 1000 --hint=int:transient:1 "Volume up $PERC%" "Current is $CURVOL %" --icon=multimedia-volume-control
+        notify-send -a pulseaudio-ctl -t 1000 -i multimedia-volume-control --hint=int:transient:1 --hint=int:value:$UPPER_THRESHOLD_AWARE_VOL --hint=string:synchronous:volume "Volume up $PERC %" "" ||
+        notify-send -a pulseaudio-ctl -t 1000 --hint=int:transient:1 "Volume up $PERC%" "Current is $CURVOL %" --icon=multimedia-volume-control
     fi
     [[ $USEK -eq 1 ]] &&
       kde_osd $CURVOL
@@ -216,8 +216,8 @@ case "$1" in
     refreshbarvolperc
     if [[ $USEN -eq 1 ]]; then
       [[ $USEB -eq 1 ]] &&
-        notify-send -t 1000 -i multimedia-volume-control --hint=int:transient:1 --hint=int:value:$UPPER_THRESHOLD_AWARE_VOL --hint=string:synchronous:volume "Volume down $PERC %" "" ||
-        notify-send -t 1000 --hint=int:transient:1 "Volume down $PERC%" "Current is $CURVOL %" --icon=multimedia-volume-control
+        notify-send -a pulseaudio-ctl -t 1000 -i multimedia-volume-control --hint=int:transient:1 --hint=int:value:$UPPER_THRESHOLD_AWARE_VOL --hint=string:synchronous:volume "Volume down $PERC %" "" ||
+        notify-send -a pulseaudio-ctl -t 1000 --hint=int:transient:1 "Volume down $PERC%" "Current is $CURVOL %" --icon=multimedia-volume-control
     fi
     [[ $USEK -eq 1 ]] &&
       kde_osd $CURVOL
@@ -231,7 +231,7 @@ case "$1" in
     pactl set-sink-mute "$SINK" "$NEW_MUTE"
     MUTED=$(pacmd list-sinks|grep -A 15 '* index'|awk '/muted:/{ print $2 }')
     [[ $USEN -eq 1 ]] &&
-      notify-send -t 1000 --hint=int:transient:1 "Mute toggle" "Muted: $MUTED" --icon=audio-volume-muted
+      notify-send -a pulseaudio-ctl -t 1000 --hint=int:transient:1 "Mute toggle" "Muted: $MUTED" --icon=audio-volume-muted
     if [[ $USEK -eq 1 ]]; then
       if [[ $MUTED == "yes" ]]; then
         kde_osd 0
@@ -250,7 +250,7 @@ case "$1" in
     pactl set-source-mute "$SOURCE" "$NEW_MUTE"
     SOURCE_MUTED=$(pacmd list-sources|grep -A 15 '* index'|awk '/muted:/{ print $2 }')
     [[ $USEN -eq 1 ]] &&
-      notify-send -t 1000 --hint=int:transient:1 "Mute toggle" "Muted: $SOURCE_MUTED" --icon=audio-volume-muted
+      notify-send -a pulseaudio-ctl -t 1000 --hint=int:transient:1 "Mute toggle" "Muted: $SOURCE_MUTED" --icon=audio-volume-muted
     if [[ $USEK -eq 1 ]]; then
       if [[ $SOURCE_MUTED == "yes" ]]; then
         kde_osd_mic 0
@@ -270,7 +270,7 @@ case "$1" in
       esac
     refreshcurvol
     [[ $USEN -eq 1 ]] &&
-      notify-send -t 1000 --hint=int:transient:1 "Volume set" "Level: $CURVOL" --icon=multimedia-volume-control
+      notify-send -a pulseaudio-ctl -t 1000 --hint=int:transient:1 "Volume set" "Level: $CURVOL" --icon=multimedia-volume-control
     [[ $USEK -eq 1 ]] &&
       kde_osd $CURVOL
     ;;
@@ -285,7 +285,7 @@ case "$1" in
       esac
     refreshcurvol
     [[ $USEN -eq 1 ]] &&
-      notify-send -t 1000 --hint=int:transient:1 "Atmost set" "Level: $CURVOL" --icon=multimedia-volume-control
+      notify-send -a pulseaudio-ctl -t 1000 --hint=int:transient:1 "Atmost set" "Level: $CURVOL" --icon=multimedia-volume-control
     [[ $USEK -eq 1 ]] &&
       kde_osd $CURVOL
     ;;
@@ -301,7 +301,7 @@ case "$1" in
   *)
     # send to notify-send if enabled
     [[ $USEN -eq 1 ]] &&
-      notify-send -t 8000 --hint=int:transient:1 "Pulseaudio Settings" "Volume level     : $CURVOL %\nIs sink muted    : $MUTED\nIs source muted  : $SOURCE_MUTED\nDetected sink    : $SINK\nDetected source  : $SOURCE\nPulse version    : $PAVERSION" --icon=multimedia-volume-control
+      notify-send -a pulseaudio-ctl -t 8000 --hint=int:transient:1 "Pulseaudio Settings" "Volume level     : $CURVOL %\nIs sink muted    : $MUTED\nIs source muted  : $SOURCE_MUTED\nDetected sink    : $SINK\nDetected source  : $SOURCE\nPulse version    : $PAVERSION" --icon=multimedia-volume-control
     # add pretty colors for mute status for CLI only
     [[ "$MUTED" = "yes" ]] && MUTED="${NRM}${RED}$MUTED${NRM}" ||
       MUTED="${NRM}${GRN}$MUTED${NRM}"


### PR DESCRIPTION
notifications get exposed currently as notify-send, which is a quite common name. Setting the appname with `-a` to `pulseaudio-ctl`, notifications are able to get processed specially by notification managers (like dunst).