### PR TITLE
Calculate the expression of the upper threshold vol

### DIFF
--- a/common/pulseaudio-ctl.in
+++ b/common/pulseaudio-ctl.in
@@ -150,7 +150,7 @@ refreshsrcvol() {
 refreshbarvolperc() {
   # calculates the volume percentage based on UPPER_THRESHOLD
   # for proper display in the bar
-  UPPER_THRESHOLD_AWARE_VOL=$CURVOL*100/$UPPER_THRESHOLD
+  UPPER_THRESHOLD_AWARE_VOL=$(($CURVOL*100/$UPPER_THRESHOLD))
 }
 
 setup() {


### PR DESCRIPTION
When setting the `UPPER_THRESHOLD` and using the notification's progress hint. `UPPER_THRESHOLD_AWARE_VOL` should not exceed 100. But it does, as the expression does not get caluculated, resulting in such a flag `--hint=int:progress:120*100/150` which is equivalent to `--hint=int:progress:120`.