### PR TITLE
Multiple Makefile fixes:

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,20 +9,15 @@ ZSHDIR = $(PREFIX)/share/zsh/site-functions
 RM = rm
 Q = @
 
-all: common/$(PN) doc/$(PN).1.gz
+all: common/$(PN)
 
 common/$(PN): common/$(PN).in
 	$(Q)echo -e '\033[1;32mSetting version\033[0m'
 	$(Q)sed -e 's/@VERSION@/'$(VERSION)'/' common/$(PN).in >common/$(PN)
 	$(Q)sed -i common/$(PN) -e 's|@SKELDIR@|'$(SKELDIR)'|'
 
-doc/$(PN).1.gz: doc/$(PN).1
-	$(Q)echo -e '\033[1;32mCompressing manpage\033[0m'
-	gzip -9 -c doc/$(PN).1 > doc/$(PN).1.gz
-
 clean:
 	$(RM) -f common/$(PN)
-	$(RM) -f doc/$(PN).1.gz
 
 install-bin:
 	$(Q)echo -e '\033[1;32mInstalling main script and config...\033[0m'
@@ -33,11 +28,11 @@ install-bin:
 
 install-man:
 	$(Q)echo -e '\033[1;32mInstalling manpage...\033[0m'
-	install -Dm644 doc/$(PN).1.gz "$(DESTDIR)$(MANDIR)/$(PN).1.gz"
+	install -Dm644 doc/$(PN).1 "$(DESTDIR)$(MANDIR)/$(PN).1"
 
 uninstall:
 	$(RM) "$(DESTDIR)$(BINDIR)/$(PN)"
-	$(RM) "$(DESTDIR)$(MANDIR)/$(PN).1.gz"
+	$(RM) "$(DESTDIR)$(MANDIR)/$(PN).1"
 	$(RM) -rf "$(DESTDIR)$(SKELDIR)"
 	$(RM) "$(DESTDIR)$(ZSHDIR)/_pulseaudio-ctl"
 

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ common/$(PN): common/$(PN).in
 clean:
 	$(RM) -f common/$(PN)
 
-install-bin:
+install-bin: common/$(PN)
 	$(Q)echo -e '\033[1;32mInstalling main script and config...\033[0m'
 	install -Dm755 common/$(PN) "$(DESTDIR)$(BINDIR)/$(PN)"
 	install -Dm644 common/config.skel "$(DESTDIR)$(SKELDIR)/config.skel"
@@ -36,6 +36,6 @@ uninstall:
 	$(RM) -rf "$(DESTDIR)$(SKELDIR)"
 	$(RM) "$(DESTDIR)$(ZSHDIR)/_pulseaudio-ctl"
 
-install: all install-bin install-man
+install: install-bin install-man
 
 .PHONY: all clean install-bin install-man uninstall

--- a/Makefile
+++ b/Makefile
@@ -21,14 +21,15 @@ clean:
 
 install-bin: common/$(PN)
 	$(Q)echo -e '\033[1;32mInstalling main script and config...\033[0m'
-	install -Dm755 common/$(PN) "$(DESTDIR)$(BINDIR)/$(PN)"
-	install -Dm644 common/config.skel "$(DESTDIR)$(SKELDIR)/config.skel"
-	install -p -dm755 "$(DESTDIR)$(ZSHDIR)"
-	install -Dm644 common/zsh-completion "$(DESTDIR)$(ZSHDIR)/_pulseaudio-ctl"
+	install -d -m755 "$(DESTDIR)$(BINDIR)" "$(DESTDIR)$(SKELDIR)" "$(DESTDIR)$(ZSHDIR)"
+	install -m755 common/$(PN) "$(DESTDIR)$(BINDIR)/$(PN)"
+	install -m644 common/config.skel "$(DESTDIR)$(SKELDIR)/config.skel"
+	install -m644 common/zsh-completion "$(DESTDIR)$(ZSHDIR)/_pulseaudio-ctl"
 
 install-man:
 	$(Q)echo -e '\033[1;32mInstalling manpage...\033[0m'
-	install -Dm644 doc/$(PN).1 "$(DESTDIR)$(MANDIR)/$(PN).1"
+	install -d -m755 "$(DESTDIR)$(MANDIR)"
+	install -m644 doc/$(PN).1 "$(DESTDIR)$(MANDIR)/$(PN).1"
 
 uninstall:
 	$(RM) "$(DESTDIR)$(BINDIR)/$(PN)"


### PR DESCRIPTION
1. Stop compressing manpage implicitly.
2. Use explicit dependencies for `install-bin` target.
3. Fix `install(1)` usage to be portable to non-GNU systems.