### PR TITLE
Fix OSD for Plasma 5.21

### DIFF
--- a/common/pulseaudio-ctl.in
+++ b/common/pulseaudio-ctl.in
@@ -174,11 +174,11 @@ setup() {
 }
 
 kde_osd() {
-  dbus-send --session --dest="org.freedesktop.Notifications" --type="method_call" "/org/kde/osdService" "org.kde.osdService.volumeChanged" "int32:$1"
+  dbus-send --session --dest="org.kde.plasmashell" --type="method_call" "/org/kde/osdService" "org.kde.osdService.volumeChanged" "int32:$1" "int32:$UPPER_THRESHOLD"
 }
 
 kde_osd_mic() {
-  dbus-send --session --dest="org.freedesktop.Notifications" --type="method_call" "/org/kde/osdService" "org.kde.osdService.mediaPlayerVolumeChanged" "int32:$1" "string:" "string:audio-input-microphone"
+  dbus-send --session --dest="org.kde.plasmashell" --type="method_call" "/org/kde/osdService" "org.kde.osdService.mediaPlayerVolumeChanged" "int32:$1" "string:" "string:audio-input-microphone"
 }
 
 checkconfig


### PR DESCRIPTION
Modifies the dbus-send command for working with Plasma 5.21.

Seems like the call admits a second argument to provide the max volume representation of the osd bar.

Fixes: #63